### PR TITLE
fix: Properly handling broken pipe errors instead of panic-ing

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use std::fs::read;
+use std::io::{stdout, Write};
 
 use clap::Parser;
 use ignore::WalkBuilder;
@@ -45,11 +46,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let hash_str = to_hex(hash.as_slice());
 
         if opt.verbose {
-            println!(
-                "{}  {}",
-                hash_str,
-                dir_entry.path().to_str().unwrap_or(""),
-            );
+            writeln!(stdout(), "{}  {}", hash_str, dir_entry.path().to_str().unwrap_or(""))?;
         }
 
         hashes.push(hash_str);
@@ -68,7 +65,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let final_hash = Sha256::digest(concatenated_hashes.as_bytes());
     let final_hash_str = to_hex(final_hash.as_slice());
 
-    println!("{}", final_hash_str);
+    writeln!(stdout(), "{}", final_hash_str)?;
 
     Ok(())
 }


### PR DESCRIPTION
#### Previously

```bash
cargo run examples/simple-nodejs  | grep
Usage: grep [OPTION]... PATTERNS [FILE]...
Try 'grep --help' for more information.
   Compiling shakshuka v0.2.0 (/home/raytung/src/github.com/raytung/shakshuka)
    Finished dev [unoptimized + debuginfo] target(s) in 1.31s
     Running `target/debug/shk examples/simple-nodejs`
thread 'main' panicked at 'failed printing to stdout: Broken pipe (os error 32)', library/std/src/io/stdio.rs:1201:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

#### This PR

```bash
cargo run examples/simple-nodejs  | grep
Usage: grep [OPTION]... PATTERNS [FILE]...
Try 'grep --help' for more information.
   Compiling shakshuka v0.2.0 (/home/raytung/src/github.com/raytung/shakshuka)
    Finished dev [unoptimized + debuginfo] target(s) in 1.32s
     Running `target/debug/shk examples/simple-nodejs`
Error: Os { code: 32, kind: BrokenPipe, message: "Broken pipe" }
```